### PR TITLE
Remove duplicate has function

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,6 @@ exports.compare = function (a, b) {
   return a < b ? -1 : a > b ? 1 : 0
 }
 
-function has(obj, key) {
-  return Object.hasOwnProperty.call(obj, key)
-}
-
 // to be compatible with the current abstract-leveldown tests
 // nullish or empty strings.
 // I could use !!val but I want to permit numbers and booleans,


### PR DESCRIPTION
Duplicate has function throws error when used with Google Closure compiler.